### PR TITLE
ER: Support Multiple Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Please watch the following video to see a demonstration of the just-in-time acce
 * [Full Install and Config Video](https://oneidentity.github.io/ActiveRoles-Safeguard-JIT-Access/install.html "Install Video")
 * [Download the installer and scripts](https://github.com/OneIdentity/ActiveRoles-Safeguard-JIT-Access/releases "Release")
 
-
 ## Support
 One Identity open source projects are supported through One Identity GitHub issues and the One Identity Community. This includes all scripts, plugins, SDKs, modules, code snippets or other solutions. For assistance with any One Identity GitHub project, please raise a new Issue on the One Identity GitHub project page. You may also visit the One Identity Community to ask questions. Requests for assistance made through official One Identity Support will be referred back to GitHub and the One Identity Community forums where those requests can benefit all users.
+
+# New in 6.7.1
+* specify a custom config file 
+* install and uninstall multiple instances of the service.
+
+Users may desire to install multiple instances of Active Roles Just-in-Time Provisioning for Safeguard in situations where different configurations are needed. Examples would include having multiple services to toggle different ARS Attributes, connect to different Safeguard for Privileged Password appliances, or use different ARS or Safeguard accounts. 
+
+## Create config file from configuration workflow
+ARSGJITAccess.exe -config <file path> 
+
+## Manually Start Service with Custom Config File
+ARSGJITAccess.exe -ConfigFile <path_to_config_file>
+
+## Install Multiple Instances
+ARSGJitAccess.exe -installAndConfigureInstance "<instance_name>"
+
+## Uninstall an Instance
+ARSGJITAccess.exe -uninstallService "<instance_name>"

--- a/src/Installer/Product.wxs
+++ b/src/Installer/Product.wxs
@@ -28,6 +28,7 @@
         <ComponentRef Id="Common_dll"/>
         <ComponentRef Id="SignalR_dll"/>
         <ComponentRef Id="Topshelf_Serilog_dll"/>
+        <ComponentRef Id="Topshelf_StartParameters_dll"/>
         <ComponentRef Id="Topshelf_dll"/>
         <ComponentRef Id="Newtonsoft_dll"/>
         <ComponentRef Id="SafeguardDotNet_dll"/>
@@ -104,6 +105,9 @@
             </Component>
             <Component Id="ARSGJitAccess.exe.config">
               <File Id="ARSGJitAccess.exe.config" Source="$(var.SolutionDir)Service\bin\Release\ARSGJitAccess.exe.config" Name="ARSGJitAccess.exe.config" />
+            </Component>
+            <Component Id="Topshelf_StartParameters_dll">
+              <File Id="Topshelf_StartParameters_dll" Source="$(var.SolutionDir)Service\bin\Release\Topshelf.StartParameters.dll" Name="Topshelf.StartParameters.dll" />
             </Component>
           </Directory>
         </Directory>

--- a/src/Service/App.config
+++ b/src/Service/App.config
@@ -60,6 +60,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.215" newVersion="4.2.1.215" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Service/Config.cs
+++ b/src/Service/Config.cs
@@ -582,15 +582,19 @@ namespace OneIdentity.ARSGJitAccess.Service
 
             Environment.Exit(0);
         }
-        public static void UninstallService()
+        public static void UninstallService(string instanceName = null)
         {
             Console.WriteLine("-----------------------------");
             Console.WriteLine("ARSGJitAccess Service Uninstall");
             Console.WriteLine("-----------------------------");
 
+            var args = "uninstall";
+            if (!string.IsNullOrEmpty(instanceName))
+                args += $" -instance {instanceName}";
+
             var info = new ProcessStartInfo
             {
-                Arguments = "uninstall",
+                Arguments = args,
                 FileName = "ARSGJitAccess.exe",
                 UseShellExecute = false
             };

--- a/src/Service/Config.cs
+++ b/src/Service/Config.cs
@@ -551,15 +551,21 @@ namespace OneIdentity.ARSGJitAccess.Service
             }
         }
 
-        public static void InstallService()
+        public static void InstallService(string instanceName = null)
         {
             Console.WriteLine("-----------------------------");
             Console.WriteLine("ARSGJitAccess Service Install");
             Console.WriteLine("-----------------------------");
 
+            string arguments = "install";
+            if(!string.IsNullOrEmpty(_configPath))
+                arguments += $" -ConfigFile \"{_configFile.FilePath}\"";
+            if (!string.IsNullOrEmpty(instanceName))
+                arguments += $" -instance \"{instanceName}\"";
+
             var info = new ProcessStartInfo
             {
-                Arguments = "install",
+                Arguments = arguments,
                 FileName = "ARSGJitAccess.exe",
                 UseShellExecute = false
             };

--- a/src/Service/Config.cs
+++ b/src/Service/Config.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.IO;
 using Newtonsoft.Json.Linq;
 using OneIdentity.ARSGJitAccess.Common;
 using OneIdentity.SafeguardDotNet;
@@ -110,6 +111,15 @@ namespace OneIdentity.ARSGJitAccess.Service
             }
         }
 
+        internal static void SetConfigFile(string v)
+        {
+            _configPath = v.Replace(".config","");
+
+            File.Create(_configPath).Close();
+            _configFile = ConfigurationManager.OpenExeConfiguration(_configPath);
+            File.Delete(_configPath);
+        }
+
         public static SecureString SafeguardPassword
         {
             get
@@ -124,7 +134,10 @@ namespace OneIdentity.ARSGJitAccess.Service
 
         static string EmptyAsNull(string setting)
         {
-            var value = ConfigurationManager.AppSettings[setting];
+            var configFile = _configFile ?? ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+
+            var value = configFile.AppSettings.Settings[setting]?.Value;
+
             if (value == null || value.Length == 0)
             {
                 return null;
@@ -134,7 +147,10 @@ namespace OneIdentity.ARSGJitAccess.Service
 
         static SecureString AsSecureStringEmptyAsNull(string setting)
         {
-            var value = ConfigurationManager.AppSettings[setting];
+            var configFile = _configFile ?? ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+
+            var value = configFile.AppSettings.Settings[setting]?.Value;
+
             if (value == null || value.Length == 0)
             {
                 return null;
@@ -153,39 +169,90 @@ namespace OneIdentity.ARSGJitAccess.Service
             return secureString;
         }
 
+        private static string _configPath = null;
+        private static Configuration _configFile = null; 
+
+        public static void ConfigureFromFile()
+        {
+
+            Console.WriteLine("--------------------------------");
+            Console.WriteLine("ARSGJitAccess File Configuration");
+            Console.WriteLine("--------------------------------");
+
+            string dir = null;
+            while (!Directory.Exists(dir))
+            {
+                dir = GetSettingInput("Enter Configuration Directory Path. Empty for default");
+                if (string.IsNullOrEmpty(dir))
+                {
+                    Console.WriteLine("Using default");
+                    _configPath = null;
+                    return;
+                }
+            }
+
+            Console.WriteLine($"Directory {dir} exists.");
+
+            var fileName = GetSettingInput("Enter Configuration filename. Empty for default (ARSGJIT.config)");
+            if (string.IsNullOrEmpty(fileName))
+                fileName = "ARSGJIT";
+            else
+                fileName = fileName.Split('.')[0];
+
+            try
+            {
+                _configPath = Path.Combine(dir, fileName);
+
+                //This is a little acrobatic, but hear me out. 
+                //Using System.Configuration makes config read / write consistent regardless of whether it's the app.config or 
+                //a user's config file. 
+                //For that to work, ConfigurationManager.OpenExeConfiguration() needs an exe to open, or create, a config file.
+                //so we temporarily create an exe with the path and filename provided by the user, then open the configuration,
+                //then delete the exe. leaving us with file <filename>.exe.config. 
+                //Even when provided a file with .config extension, OpenExeConfiguration creates a new file with .config
+                //i.e, if provided MyArsgConfig.config, it would create and use MyArsgConfig.config.config. 
+                File.Create(_configPath + ".exe").Close();
+                _configFile = ConfigurationManager.OpenExeConfiguration(_configPath + ".exe");
+                File.Delete(_configPath + ".exe");
+            }
+
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: failed to create file {_configPath}. Message: {ex.Message}");
+                System.Environment.Exit(1);
+            }
+
+            Console.WriteLine($"File {_configPath}.exe.config successfully created.");
+
+            Console.WriteLine("-----------------------------------------");
+            Console.WriteLine("ARSGJitAccess File Configuration Complete");
+            Console.WriteLine("-----------------------------------------");
+        }
+
         public static void ConfigureAppSettings()
         {
             Console.WriteLine("---------------------------");
             Console.WriteLine("ARSGJitAccess Configuration");
             Console.WriteLine("---------------------------");
 
-            switch (GetServiceAuthType())
-            {
-                //no input; skip
-                case 0:
-                    break;
-                //Log on as Service option
-                case 1:
-                    ClearAppSetting("ActiveRolesUsername");
-                    ClearAppSetting("ActiveRolesPassword");
-
-                    break;
-                //Username / Password option
-                case 2:
-                    var arsUserName = GetSettingInput("ARS Username", ActiveRolesUsername);
-                    ActiveRolesUsername = arsUserName;
-
-                    ActiveRolesPassword = string.IsNullOrEmpty(ActiveRolesPassword) ?
-                        GetSettingInput("Initial ARS Password") :
-                        GetSettingInput("Initial ARS Password", new string('*', ActiveRolesPassword.Length));
-                    break;
-            }
+            int serviceAuthTypeSelection = GetServiceAuthType();
+            ConfigureServiceAuthType(serviceAuthTypeSelection);
 
             ARSGJitAccessAttribute = GetSettingInput("ARS Access Attribute", ARSGJitAccessAttribute);
 
             SafeguardAppliance = GetAndValidateApplianceAddress();
 
-            switch (GetSafeguardAuthType())
+            int safeguardAuthTypeSelection = GetSafeguardAuthType();
+            ConfigureSafeguardAuthType(safeguardAuthTypeSelection);
+
+            Console.WriteLine("------------------------------------");
+            Console.WriteLine("ARSGJitAccess Configuration Complete");
+            Console.WriteLine("------------------------------------");
+        }
+
+        private static void ConfigureSafeguardAuthType(int SafeguardAuthType)
+        {
+            switch (SafeguardAuthType)
             {
                 //no input; skip
                 case 0:
@@ -231,17 +298,30 @@ namespace OneIdentity.ARSGJitAccess.Service
 
                     break;
             }
-
-            Console.WriteLine("------------------------------------");
-            Console.WriteLine("ARSGJitAccess Configuration Complete");
-            Console.WriteLine("------------------------------------");
         }
 
-        private static string GetPassword(string pwd, string instruction)
+        private static void ConfigureServiceAuthType(int ServiceAuthType)
         {
-            return string.IsNullOrEmpty(pwd) ?
-                GetSettingInput(instruction) :
-                GetSettingInput(instruction, new string('*', pwd.Length));
+            switch (ServiceAuthType)
+            {
+                //no input; skip
+                case 0:
+                    break;
+                //Log on as Service option
+                case 1:
+                    ClearAppSetting("ActiveRolesUsername");
+                    ClearAppSetting("ActiveRolesPassword");
+
+                    break;
+                //Username / Password option
+                case 2:
+                    ActiveRolesUsername = GetSettingInput("ARS Username", ActiveRolesUsername);
+
+                    ActiveRolesPassword = string.IsNullOrEmpty(ActiveRolesPassword) ?
+                        GetSettingInput("Initial ARS Password") :
+                        GetSettingInput("Initial ARS Password", new string('*', ActiveRolesPassword.Length));
+                    break;
+            }
         }
 
         private static string GetAndValidateSafeguardCertificate()
@@ -275,20 +355,27 @@ namespace OneIdentity.ARSGJitAccess.Service
 
         private static string GetAndValidateSafeguardThumbprint()
         {
-            X509Certificate2Collection matchingCerts = new X509Certificate2Collection();
+            var emptyThumbprintString = -1;
+            var matchingCertCount = 0;
 
             string safeguardCertThumbprint = "";
-            while(matchingCerts.Count == 0)
+            while(matchingCertCount <= 0)
             {
                 safeguardCertThumbprint = GetSettingInput("Safeguard User Certificate Thumbprint",
                     SafeguardCertificateThumbprint);
 
-                if (safeguardCertThumbprint == "")
-                    break;
+                matchingCertCount = ValidateSafeguardCertThumbprint(safeguardCertThumbprint);
 
-                matchingCerts = GetMatchingCerts(safeguardCertThumbprint);
-                
-                if (matchingCerts.Count == 0)
+                if(matchingCertCount == emptyThumbprintString)
+                {
+                    var resp = GetSettingInput(
+                       $"\tProvided certificate thumbprint was empty. Continue?",
+                       "y/n");
+
+                    if (String.CompareOrdinal(resp, "y") == 0)
+                        break;
+                }
+                else if (matchingCertCount == 0)
                 {
                     var resp = GetSettingInput(
                         $"\tNo certificate with thumbprint {safeguardCertThumbprint} found in current user or local machine certificate store. Continue?",
@@ -299,10 +386,24 @@ namespace OneIdentity.ARSGJitAccess.Service
                 }
             }
 
-            if(!String.IsNullOrEmpty(safeguardCertThumbprint) && matchingCerts.Count > 0)
+            if(!String.IsNullOrEmpty(safeguardCertThumbprint) && matchingCertCount > 0)
                 Console.WriteLine($"\tFound certificate with thumbprint {safeguardCertThumbprint}.");
             
             return safeguardCertThumbprint;
+        }
+
+        private static int ValidateSafeguardCertThumbprint(string safeguardCertThumbprint)
+        {
+            var emptyThumbprintString = -1;
+
+            X509Certificate2Collection matchingCerts = new X509Certificate2Collection();
+
+            if (safeguardCertThumbprint == "")
+                return emptyThumbprintString;
+
+            matchingCerts = GetMatchingCerts(safeguardCertThumbprint);
+
+            return matchingCerts.Count;
         }
 
         private static X509Certificate2Collection GetMatchingCerts(string thumbprint, bool searchLocalMachine = true)
@@ -331,11 +432,11 @@ namespace OneIdentity.ARSGJitAccess.Service
             string applianceAddress = null;
             JObject response = null;
             var isValid = false;
-            while (response == null && !isValid)
+           while (response == null && !isValid)
             {
                 applianceAddress = GetSettingInput("Safeguard Appliance Address", SafeguardAppliance);
-
-                if (String.IsNullOrEmpty(applianceAddress))
+                
+                if (string.IsNullOrEmpty(applianceAddress))
                     return applianceAddress;
 
                 isValid = SafeguardRestApiClient.ValidateSafeguardApplianceAddress(applianceAddress, out response);
@@ -405,7 +506,8 @@ namespace OneIdentity.ARSGJitAccess.Service
         {
             try
             {
-                var configFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                var configFile = _configFile ?? ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+
                 var settings = configFile.AppSettings.Settings;
 
                 if (settings[key] == null)
@@ -430,7 +532,8 @@ namespace OneIdentity.ARSGJitAccess.Service
 
             try
             {
-                var configFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                var configFile = _configFile ?? ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+
                 var settings = configFile.AppSettings.Settings;
 
                 if (settings[key] == null)
@@ -439,6 +542,7 @@ namespace OneIdentity.ARSGJitAccess.Service
                     settings[key].Value = value;
 
                 configFile.Save(ConfigurationSaveMode.Modified);
+                
                 ConfigurationManager.RefreshSection(configFile.AppSettings.SectionInformation.Name);
             }
             catch (ConfigurationErrorsException ex)

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reflection;
 using System.Security;
 using Topshelf;
+using Topshelf.StartParameters;
 
 namespace OneIdentity.ARSGJitAccess.Service
 {
@@ -56,13 +57,18 @@ namespace OneIdentity.ARSGJitAccess.Service
                     Config.InstallService();
                 });
                 x.AddCommandLineDefinition("uninstallService", v => Config.UninstallService());
-                x.AddCommandLineDefinition("installAndConfigureFile", v =>
+                x.AddCommandLineDefinition("installAndConfigureInstance", v =>
                 {
                     Config.ConfigureFromFile();
                     Config.ConfigureAppSettings();
-                    Config.InstallService();
+                    Config.InstallService(v);
                 });
-                x.AddCommandLineDefinition("UseConfigFile", v => { Config.SetConfigFile(v); });
+                x.EnableStartParameters();
+                x.WithStartParameter("ConfigFile", f =>
+                {
+                    Config.SetConfigFile(f);
+                });
+
             });
 
             var exitCode = (int)Convert.ChangeType(rc, rc.GetTypeCode());  

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -55,7 +55,14 @@ namespace OneIdentity.ARSGJitAccess.Service
                     Config.ConfigureAppSettings();
                     Config.InstallService();
                 });
-                x.AddCommandLineDefinition("uninstallService", v=>Config.UninstallService());
+                x.AddCommandLineDefinition("uninstallService", v => Config.UninstallService());
+                x.AddCommandLineDefinition("installAndConfigureFile", v =>
+                {
+                    Config.ConfigureFromFile();
+                    Config.ConfigureAppSettings();
+                    Config.InstallService();
+                });
+                x.AddCommandLineDefinition("UseConfigFile", v => { Config.SetConfigFile(v); });
             });
 
             var exitCode = (int)Convert.ChangeType(rc, rc.GetTypeCode());  

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -13,7 +13,7 @@ namespace OneIdentity.ARSGJitAccess.Service
         public static readonly string AppName = "ARSGJitAccess";
         public static readonly string AppDisplayName = "Active Roles/Safeguard Just-in-time Access";
         public static readonly string AppDescription = "Listens for Safeguard access requests and call Active Roles to set permission granting attribute";
-
+        
         public static void Main()
         {
             bool isTest = false;
@@ -48,6 +48,11 @@ namespace OneIdentity.ARSGJitAccess.Service
                 x.AddCommandLineDefinition("config", v =>
                 {
                     isTest = true;
+
+                    //configure custom file
+                    if (!string.IsNullOrEmpty(v))
+                        Config.SetConfigFile(v);
+
                     Config.ConfigureAppSettings();
                 });
                 x.AddCommandLineDefinition("installAndConfigureService", v =>
@@ -56,23 +61,50 @@ namespace OneIdentity.ARSGJitAccess.Service
                     Config.ConfigureAppSettings();
                     Config.InstallService();
                 });
-                x.AddCommandLineDefinition("uninstallService", v => Config.UninstallService());
+                x.AddCommandLineDefinition("uninstallService", v => Config.UninstallService(v));
                 x.AddCommandLineDefinition("installAndConfigureInstance", v =>
                 {
-                    Config.ConfigureFromFile();
-                    Config.ConfigureAppSettings();
-                    Config.InstallService(v);
+                    isTest = true;
+
+                    if (string.IsNullOrEmpty(v))
+                    {
+                        Log.Logger.Error("Instance name must be provided");
+                    }
+                    else
+                    {
+                        Config.ConfigureFromFile();
+                        Config.ConfigureAppSettings();
+                        Config.InstallService(v);
+                    }
                 });
                 x.EnableStartParameters();
                 x.WithStartParameter("ConfigFile", f =>
                 {
                     Config.SetConfigFile(f);
                 });
+                x.SetHelpTextPrefix(BuildHelpDoc());
 
             });
 
             var exitCode = (int)Convert.ChangeType(rc, rc.GetTypeCode());  
             Environment.ExitCode = exitCode;
+        }
+
+        private static string BuildHelpDoc()
+        {
+            var header = "\n------------------------------\n" +
+                "Active Roles JIT Access for Safeguard Command-Line Reference\n" +
+                "------------------------------\n\n";
+            var test = "\t-test : tests the current configuration\n\n";
+            var config = "\t-config <file path>: launches configuration workflow and tests configuration. If no file path is provided, the default is used.\n\n";
+            var installAndConfigureService = "\t-installAndConfigureService : launches configuration workflow, tests configuration, and installs service.\n\n";
+            var installAndConfigureInstance = "\t-installAndConfigureInstance <name>: prompts for configuration file path, launches configuration workflow, " +
+                "and installs service with specified instance name and config file parameter.\n\n";
+            var configFile = "\t-ConfigFile : Specifies a custom config file for the service to use\n";
+            var footer = "\n------------------------------\n";
+
+
+            return string.Concat(new String[]{header,test,config,installAndConfigureService,installAndConfigureInstance,configFile,footer});
         }
     }
 }

--- a/src/Service/Properties/AssemblyInfo.cs
+++ b/src/Service/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("6.7.1.0")]
+[assembly: AssemblyFileVersion("6.7.1.0")]

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -81,6 +81,9 @@
     <Reference Include="Topshelf.Serilog, Version=4.2.1.215, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\packages\Topshelf.Serilog.4.2.1\lib\net452\Topshelf.Serilog.dll</HintPath>
     </Reference>
+    <Reference Include="Topshelf.StartParameters, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.StartParameters.1.0.2\lib\net462\Topshelf.StartParameters.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config.cs" />

--- a/src/Service/packages.config
+++ b/src/Service/packages.config
@@ -11,4 +11,5 @@
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net472" />
   <package id="Topshelf" version="4.2.1" targetFramework="net472" />
   <package id="Topshelf.Serilog" version="4.2.1" targetFramework="net472" />
+  <package id="Topshelf.StartParameters" version="1.0.2" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
These changes support multiple instances and custom config files. 

Topshelf allows multiple instances to be installed using the -instance <name> parameter. The changes needed in our code to make use of that included updating command line parameters to take an instance name (uninstallService, installService) and updating Config logic to include instance name where provided. 

It doesn't, however, include a way to specify a custom config file for an installed instance. I added the nuget package Topshelf.StartParameters() which allows you to specify start parameters at install time and added command line parameters to specify a config file, edit a config file, and create a config file at install time. 

Along the way I reorganized some of our logic in Config.cs into separate methods instead of being embedded in switch statements, added help info about our command line parameters, and changed our versioning strategy to align with One Identity Safeguard for Privileged Passwords.