### PR TITLE
ISSUE #2: ARSGJIT-Access doesn't work with SPP 6.8+

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.0.0" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.8.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.DirectoryServices" Version="4.7.0" />
   </ItemGroup>

--- a/src/Installer/Product.wxs
+++ b/src/Installer/Product.wxs
@@ -27,6 +27,7 @@
         <ComponentRef Id="ARSGJITACCESS_EXE"/>
         <ComponentRef Id="Common_dll"/>
         <ComponentRef Id="SignalR_dll"/>
+        <ComponentRef Id="SignalR_Core_dll"/>
         <ComponentRef Id="Topshelf_Serilog_dll"/>
         <ComponentRef Id="Topshelf_StartParameters_dll"/>
         <ComponentRef Id="Topshelf_dll"/>
@@ -37,6 +38,35 @@
         <ComponentRef Id="Serilog_Sinks_Console_dll"/>
         <ComponentRef Id="Serilog_Sinks_EventLog_dll"/>
         <ComponentRef Id="ARSGJitAccess.exe.config"/>
+
+        <ComponentRef Id="Microsoft_AspNetCore_Connections_Abstractions_dll"/>
+        <ComponentRef Id="Microsoft_AspNetCore_Http_Connections_Client_dll"/>
+        <ComponentRef Id="Microsoft_AspNetCore_Http_Connections_Common_dll"/>
+        <ComponentRef Id="Microsoft_AspNetCore_Http_Features_dll"/>
+        <ComponentRef Id="Microsoft_AspNetCore_SignalR_Common_dll"/>
+        <ComponentRef Id="Microsoft_AspNetCore_SignalR_Protocols_Json_dll"/>
+        <ComponentRef Id="Microsoft_Bcl_AsyncInterfaces_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Configuration_Abstractions_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Configuration_Binder_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Configuration_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_DependencyInjection_Abstractions_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_DependencyInjection_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Logging_Abstractions_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Logging_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Options_dll"/>
+        <ComponentRef Id="Microsoft_Extensions_Primitives_dll"/>
+        <ComponentRef Id="System_Buffers_dll"/>
+        <ComponentRef Id="System_ComponentModel_Annotations_dll"/>
+        <ComponentRef Id="System_IO_Pipelines_dll"/>
+        <ComponentRef Id="System_Memory_dll"/>
+        <ComponentRef Id="System_Numerics_Vectors_dll"/>
+        <ComponentRef Id="System_Runtime_CompilerServices_Unsafe_dll"/>
+        <ComponentRef Id="System_Text_Encodings_Web_dll"/>
+        <ComponentRef Id="System_Text_Json_dll"/>
+        <ComponentRef Id="System_Threading_Channels_dll"/>
+        <ComponentRef Id="System_Threading_Tasks_Extensions_dll"/>
+        <ComponentRef Id="System_ValueTuple_dll"/>
+
       </Feature>
     </Feature>
 
@@ -76,17 +106,74 @@
             <Component Id="Common_dll">
               <File Id="Common_dll" Source="$(var.SolutionDir)Service\bin\Release\ARSGJitAccessCommon.dll" Name="ARSGJitAccessCommon.dll" />
             </Component>
-            <Component Id="SignalR_dll">
-              <File Id="SignalR_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNet.SignalR.Client.dll" Name="Microsoft.AspNet.SignalR.Client.dll" />
+            <Component Id="SignalR_Core_dll">
+              <File Id="SignalR_Core_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.SignalR.Client.Core.dll" Name="Microsoft.AspNetCore.SignalR.Client.Core.dll" />
             </Component>
+            <Component Id="SignalR_dll">
+              <File Id="SignalR_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.SignalR.Client.dll" Name="Microsoft.AspNetCore.SignalR.Client.dll" />
+            </Component>
+
+            <Component Id="Microsoft_AspNetCore_Connections_Abstractions_dll">
+              <File Id="Microsoft_AspNetCore_Connections_Abstractions_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.Connections.Abstractions.dll" Name="Microsoft.AspNetCore.Connections.Abstractions.dll" />
+            </Component>
+            <Component Id="Microsoft_AspNetCore_Http_Connections_Client_dll">
+              <File Id="Microsoft_AspNetCore_Http_Connections_Client_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.Http.Connections.Client.dll" Name="Microsoft.AspNetCore.Http.Connections.Client.dll" />
+            </Component>
+            <Component Id="Microsoft_AspNetCore_Http_Connections_Common_dll">
+              <File Id="Microsoft_AspNetCore_Http_Connections_Common_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.Http.Connections.Common.dll" Name="Microsoft.AspNetCore.Http.Connections.Common.dll" />
+            </Component>
+            <Component Id="Microsoft_AspNetCore_Http_Features_dll">
+              <File Id="Microsoft_AspNetCore_Http_Features_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.Http.Features.dll" Name="Microsoft.AspNetCore.Http.Features.dll" />
+            </Component>
+            <Component Id="Microsoft_AspNetCore_SignalR_Common_dll">
+              <File Id="Microsoft_AspNetCore_SignalR_Common_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.SignalR.Common.dll" Name="Microsoft.AspNetCore.SignalR.Common.dll" />
+            </Component>
+            <Component Id="Microsoft_AspNetCore_SignalR_Protocols_Json_dll">
+              <File Id="Microsoft_AspNetCore_SignalR_Protocols_Json_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.AspNetCore.SignalR.Protocols.Json.dll" Name="Microsoft.AspNetCore.SignalR.Protocols.Json.dll" />
+            </Component>
+            <Component Id="Microsoft_Bcl_AsyncInterfaces_dll">
+              <File Id="Microsoft_Bcl_AsyncInterfaces_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Bcl.AsyncInterfaces.dll" Name="Microsoft.Bcl.AsyncInterfaces.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Configuration_Abstractions_dll">
+              <File Id="Microsoft_Extensions_Configuration_Abstractions_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Configuration.Abstractions.dll" Name="Microsoft.Extensions.Configuration.Abstractions.dll" />
+            </Component>
+
+            <Component Id="Microsoft_Extensions_Configuration_Binder_dll">
+              <File Id="Microsoft_Extensions_Configuration_Binder_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Configuration.Binder.dll" Name="Microsoft.Extensions.Configuration.Binder.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Configuration_dll">
+              <File Id="Microsoft_Extensions_Configuration_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Configuration.dll" Name="Microsoft.Extensions.Configuration.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_DependencyInjection_Abstractions_dll">
+              <File Id="Microsoft_Extensions_DependencyInjection_Abstractions_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.DependencyInjection.Abstractions.dll" Name="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_DependencyInjection_dll">
+              <File Id="Microsoft_Extensions_DependencyInjection_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.DependencyInjection.dll" Name="Microsoft.Extensions.DependencyInjection.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Logging_Abstractions_dll">
+              <File Id="Microsoft_Extensions_Logging_Abstractions_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Logging.Abstractions.dll" Name="Microsoft.Extensions.Logging.Abstractions.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Logging_dll">
+              <File Id="Microsoft_Extensions_Logging_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Logging.dll" Name="Microsoft.Extensions.Logging.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Options_dll">
+              <File Id="Microsoft_Extensions_Options_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Options.dll" Name="Microsoft.Extensions.Options.dll" />
+            </Component>
+            <Component Id="Microsoft_Extensions_Primitives_dll">
+              <File Id="Microsoft_Extensions_Primitives_dll" Source="$(var.SolutionDir)Service\bin\Release\Microsoft.Extensions.Primitives.dll" Name="Microsoft.Extensions.Primitives.dll" />
+            </Component>
+            
+            
+            
+            
             <Component Id="Newtonsoft_dll">
               <File Id="Newtonsoft_dll" Source="$(var.SolutionDir)Service\bin\Release\Newtonsoft.Json.dll" Name="Newtonsoft.Json.dll" />
             </Component>
-            <Component Id="SafeguardDotNet_dll">
-              <File Id="SafeguardDotNet_dll" Source="$(var.SolutionDir)Service\bin\Release\OneIdentity.SafeguardDotNet.dll" Name="OneIdentity.SafeguardDotNet.dll" />
-            </Component>
             <Component Id="RestSharp_dll">
               <File Id="RestSharp_dll" Source="$(var.SolutionDir)Service\bin\Release\RestSharp.dll" Name="RestSharp.dll" />
+            </Component>
+            <Component Id="SafeguardDotNet_dll">
+              <File Id="SafeguardDotNet_dll" Source="$(var.SolutionDir)Service\bin\Release\OneIdentity.SafeguardDotNet.dll" Name="OneIdentity.SafeguardDotNet.dll" />
             </Component>
             <Component Id="Serilog_dll">
               <File Id="Serilog_dll" Source="$(var.SolutionDir)Service\bin\Release\Serilog.dll" Name="Serilog.dll" />
@@ -97,6 +184,43 @@
             <Component Id="Serilog_Sinks_EventLog_dll">
               <File Id="Serilog_Sinks_EventLog_dll" Source="$(var.SolutionDir)Service\bin\Release\Serilog.Sinks.EventLog.dll" Name="Serilog.Sinks.EventLog.dll" />
             </Component>
+
+            <Component Id="System_Buffers_dll">
+              <File Id="System_Buffers_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Buffers.dll" Name="System.Buffers.dll" />
+            </Component>
+            <Component Id="System_ComponentModel_Annotations_dll">
+              <File Id="System_ComponentModel_Annotations_dll" Source="$(var.SolutionDir)Service\bin\Release\System.ComponentModel.Annotations.dll" Name="System.ComponentModel.Annotations.dll" />
+            </Component>
+            <Component Id="System_IO_Pipelines_dll">
+              <File Id="System_IO_Pipelines_dll" Source="$(var.SolutionDir)Service\bin\Release\System.IO.Pipelines.dll" Name="System.IO.Pipelines.dll" />
+            </Component>
+            <Component Id="System_Memory_dll">
+              <File Id="System_Memory_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Memory.dll" Name="System.Memory.dll" />
+            </Component>
+            <Component Id="System_Numerics_Vectors_dll">
+              <File Id="System_Numerics_Vectors_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Numerics.Vectors.dll" Name="System.Numerics.Vectors.dll" />
+            </Component>
+            <Component Id="System_Runtime_CompilerServices_Unsafe_dll">
+              <File Id="System_Runtime_CompilerServices_Unsafe_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Runtime.CompilerServices.Unsafe.dll" Name="System.Runtime.CompilerServices.Unsafe.dll" />
+            </Component>
+            <Component Id="System_Text_Encodings_Web_dll">
+              <File Id="System_Text_Encodings_Web_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Text.Encodings.Web.dll" Name="System.Text.Encodings.Web.dll" />
+            </Component>
+            <Component Id="System_Text_Json_dll">
+              <File Id="System_Text_Json_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Text.Json.dll" Name="System.Text.Json.dll" />
+            </Component>
+            <Component Id="System_Threading_Channels_dll">
+              <File Id="System_Threading_Channels_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Threading.Channels.dll" Name="System.Threading.Channels.dll" />
+            </Component>
+            <Component Id="System_Threading_Tasks_Extensions_dll">
+              <File Id="System_Threading_Tasks_Extensions_dll" Source="$(var.SolutionDir)Service\bin\Release\System.Threading.Tasks.Extensions.dll" Name="System.Threading.Tasks.Extensions.dll" />
+            </Component>
+            <Component Id="System_ValueTuple_dll">
+              <File Id="System_ValueTuple_dll" Source="$(var.SolutionDir)Service\bin\Release\System.ValueTuple.dll" Name="System.ValueTuple.dll" />
+            </Component>
+            
+            
+
             <Component Id="Topshelf_dll">
               <File Id="Topshelf_dll" Source="$(var.SolutionDir)Service\bin\Release\Topshelf.dll" Name="Topshelf.dll" />
             </Component>
@@ -109,6 +233,10 @@
             <Component Id="Topshelf_StartParameters_dll">
               <File Id="Topshelf_StartParameters_dll" Source="$(var.SolutionDir)Service\bin\Release\Topshelf.StartParameters.dll" Name="Topshelf.StartParameters.dll" />
             </Component>
+
+           
+            
+
           </Directory>
         </Directory>
       </Directory>

--- a/src/Service/App.config
+++ b/src/Service/App.config
@@ -64,6 +64,50 @@
         <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.215" newVersion="4.2.1.215" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Service/Properties/AssemblyInfo.cs
+++ b/src/Service/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.7.1.0")]
-[assembly: AssemblyFileVersion("6.7.1.0")]
+[assembly: AssemblyVersion("6.8.0.0")]
+[assembly: AssemblyFileVersion("6.8.0.0")]

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -40,17 +40,71 @@
     <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.4.1\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.Connections.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Connections.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Connections.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Client, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Client.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Common, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Common.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Client, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Client.Core, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.Core.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Common, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Common.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Protocols.Json.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Protocols.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.3.1.7\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OneIdentity.SafeguardDotNet, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OneIdentity.SafeguardDotNet.6.0.0\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
+    <Reference Include="OneIdentity.SafeguardDotNet, Version=6.8.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\OneIdentity.SafeguardDotNet.6.8.2\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.9.0\lib\net46\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
@@ -59,15 +113,50 @@
       <HintPath>..\packages\Serilog.Sinks.EventLog.3.1.0\lib\net45\Serilog.Sinks.EventLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Pipelines, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.4.7.1\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.4.7.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Channels, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Channels.4.7.1\lib\net461\System.Threading.Channels.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -101,6 +190,9 @@
       <Project>{cc314d6b-0cc6-44eb-bcaf-3585144f2880}</Project>
       <Name>Common</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="images\SafeguardLogo.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Service/packages.config
+++ b/src/Service/packages.config
@@ -1,14 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.SignalR.Client" version="2.4.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Connections.Abstractions" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Connections.Client" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Connections.Common" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Client" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Client.Core" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Common" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Protocols.Json" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.7" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="OneIdentity.SafeguardDotNet" version="6.0.0" targetFramework="net472" />
-  <package id="RestSharp" version="106.10.1" targetFramework="net472" />
-  <package id="Serilog" version="2.9.0" targetFramework="net472" />
+  <package id="OneIdentity.SafeguardDotNet" version="6.8.2" targetFramework="net472" />
+  <package id="RestSharp" version="106.11.7" targetFramework="net472" />
+  <package id="Serilog" version="2.10.0" targetFramework="net472" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net472" />
   <package id="Serilog.Sinks.EventLog" version="3.1.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net472" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="4.7.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.7.1" targetFramework="net472" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net472" />
+  <package id="System.Threading.Channels" version="4.7.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Topshelf" version="4.2.1" targetFramework="net472" />
   <package id="Topshelf.Serilog" version="4.2.1" targetFramework="net472" />
   <package id="Topshelf.StartParameters" version="1.0.2" targetFramework="net472" />


### PR DESCRIPTION
Changes to add support for SPP 6.8 - updated to the latest version of SafeguardDotNet; updated product version number.

This is not backwards compatible. 