### PR TITLE
ISSUE 4: Authentication Denied Error and 6.9.0 Release

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.8.2" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.9.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.DirectoryServices" Version="4.7.0" />
   </ItemGroup>

--- a/src/Common/SafeguardRestApiClient.cs
+++ b/src/Common/SafeguardRestApiClient.cs
@@ -19,13 +19,13 @@ namespace OneIdentity.ARSGJitAccess.Common
 
         public SafeguardAssetAccount GetAssetAccount(string assetAccountId)
         {
-            var response = Connection.InvokeMethod(Service.Core, Method.Get, $"AssetAccounts/{assetAccountId}");
+            var response = InvokeMethod(Service.Core, Method.Get, $"AssetAccounts/{assetAccountId}");
             return JsonConvert.DeserializeObject<SafeguardAssetAccount>(response);
         }
 
         public SafeguardUser GetCurrentUser()
         {
-            var response = Connection.InvokeMethod(Service.Core, Method.Get, "Me");
+            var response = InvokeMethod(Service.Core, Method.Get, "Me");
             return JsonConvert.DeserializeObject<SafeguardUser>(response);
         }
 
@@ -35,13 +35,13 @@ namespace OneIdentity.ARSGJitAccess.Common
             {
                 {"filter",$"UserId eq {user.Id}"}
             };
-            var response = Connection.InvokeMethod(Service.Core, Method.Get, "EventSubscribers", null, parameters);
+            var response = InvokeMethod(Service.Core, Method.Get, "EventSubscribers", null, parameters);
             return JsonConvert.DeserializeObject<List<SafeguardEventSubscription>>(response);
         }
 
         public void CreateEventSubscription(SafeguardEventSubscription eventSubscription)
         {
-            Connection.InvokeMethod(Service.Core, Method.Post, "EventSubscribers", JsonConvert.SerializeObject(eventSubscription));
+            InvokeMethod(Service.Core, Method.Post, "EventSubscribers", JsonConvert.SerializeObject(eventSubscription));
         }
 
         public ISafeguardEventListener GetEventListener()
@@ -69,6 +69,16 @@ namespace OneIdentity.ARSGJitAccess.Common
             }
 
             return false;
+        }
+
+        private string InvokeMethod(Service service, Method method, string endpoint, string body = null, IDictionary<string, string> parameters = null, IDictionary<string, string> additionalHeaders = null, TimeSpan? timeout=null)
+        {
+            if (Connection.GetAccessTokenLifetimeRemaining() <= 0)
+            {
+                Log.Information("Access Token Expired. Re-authenticating to Safeguard.");
+                Connection.RefreshAccessToken();
+            }
+            return Connection.InvokeMethod(service, method, endpoint, body, parameters, additionalHeaders, timeout);            
         }
 
         ISafeguardConnection Connection

--- a/src/Service/App.config
+++ b/src/Service/App.config
@@ -58,7 +58,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />
@@ -74,15 +74,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -90,15 +90,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.7.0" newVersion="3.1.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.13.0" newVersion="3.1.13.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -107,6 +107,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -77,6 +77,42 @@ namespace OneIdentity.ARSGJitAccess.Service
                         Config.InstallService(v);
                     }
                 });
+                x.AddCommandLineDefinition("loglevel", v =>
+                {
+                    var loggerConfig = new LoggerConfiguration();
+
+                    try
+                    {
+                        switch (v)
+                        {
+                            case "information":
+                                loggerConfig = loggerConfig.MinimumLevel.Information();
+                                break;
+                            case "warning":
+                                loggerConfig = loggerConfig.MinimumLevel.Warning();
+                                break;
+                            case "debug":
+                                loggerConfig = loggerConfig.MinimumLevel.Debug();
+                                break;
+                            case "error":
+                                loggerConfig = loggerConfig.MinimumLevel.Error();
+                                break;
+                            case "verbose":
+                                loggerConfig = loggerConfig.MinimumLevel.Verbose();
+                                break;
+                        }
+
+                        Log.Logger = loggerConfig.WriteTo.Console()
+                            .WriteTo.EventLog(AppName, manageEventSource: true)
+                            .CreateLogger();
+                    }
+                    catch (SecurityException)
+                    {
+                        Log.Logger = loggerConfig.WriteTo.Console().CreateLogger();
+                        Log.Warning("Unable to access Windows Event Log.  Logging console only");
+                    }
+
+                });
                 x.EnableStartParameters();
                 x.WithStartParameter("ConfigFile", f =>
                 {
@@ -96,6 +132,7 @@ namespace OneIdentity.ARSGJitAccess.Service
                 "Active Roles JIT Access for Safeguard Command-Line Reference\n" +
                 "------------------------------\n\n";
             var test = "\t-test : tests the current configuration\n\n";
+            var loglevel = "\t-loglevel : sets the log level for the application. Options: information, warning, debug, error, verbose. Defaults to information.\n\n";
             var config = "\t-config <file path>: launches configuration workflow and tests configuration. If no file path is provided, the default is used.\n\n";
             var installAndConfigureService = "\t-installAndConfigureService : launches configuration workflow, tests configuration, and installs service.\n\n";
             var installAndConfigureInstance = "\t-installAndConfigureInstance <name>: prompts for configuration file path, launches configuration workflow, " +
@@ -104,7 +141,7 @@ namespace OneIdentity.ARSGJitAccess.Service
             var footer = "\n------------------------------\n";
 
 
-            return string.Concat(new String[]{header,test,config,installAndConfigureService,installAndConfigureInstance,configFile,footer});
+            return string.Concat(new String[]{header,test,loglevel,config,installAndConfigureService,installAndConfigureInstance,configFile,footer});
         }
     }
 }

--- a/src/Service/Properties/AssemblyInfo.cs
+++ b/src/Service/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.8.0.0")]
-[assembly: AssemblyFileVersion("6.8.0.0")]
+[assembly: AssemblyVersion("6.9.0.0")]
+[assembly: AssemblyFileVersion("6.9.0.0")]

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -40,65 +40,71 @@
     <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.4.1\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Connections.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Connections.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Connections.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Connections.Abstractions, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Connections.Abstractions.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.Connections.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Connections.Client, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Client.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Client.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Client, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Client.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Connections.Common, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Common.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Common.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Common, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Connections.Common.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.Http.Connections.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.SignalR.Client, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Client, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.SignalR.Client.Core, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.Core.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.Core.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Client.Core, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Client.Core.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Client.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.SignalR.Common, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Common.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Common.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Common, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Common.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Protocols.Json.3.1.7\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Protocols.Json.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.SignalR.Protocols.Json.3.1.13\lib\netstandard2.0\Microsoft.AspNetCore.SignalR.Protocols.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.WebUtilities.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.3.1.7\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.3.1.13\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.13\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.13.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.3.1.13\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.Headers.2.2.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
-    <Reference Include="OneIdentity.SafeguardDotNet, Version=6.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OneIdentity.SafeguardDotNet.6.8.2\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="OneIdentity.SafeguardDotNet, Version=6.9.0.4549, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\OneIdentity.SafeguardDotNet.6.9.0\lib\netstandard2.0\OneIdentity.SafeguardDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
@@ -124,11 +130,14 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Pipelines, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.4.7.1\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=4.0.2.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.4.7.4\lib\net461\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />

--- a/src/Service/packages.config
+++ b/src/Service/packages.config
@@ -1,27 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.SignalR.Client" version="2.4.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Connections.Abstractions" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Connections.Client" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Connections.Common" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Features" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.SignalR.Client" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.SignalR.Client.Core" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.SignalR.Common" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.SignalR.Protocols.Json" version="3.1.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Connections.Abstractions" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Connections.Client" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Connections.Common" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Client" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Client.Core" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Common" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.SignalR.Protocols.Json" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.2.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="3.1.7" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="3.1.7" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="OneIdentity.SafeguardDotNet" version="6.8.2" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.13" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.2.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="OneIdentity.SafeguardDotNet" version="6.9.0" targetFramework="net472" />
   <package id="RestSharp" version="106.11.7" targetFramework="net472" />
   <package id="Serilog" version="2.10.0" targetFramework="net472" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net472" />
@@ -29,7 +32,7 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net472" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net472" />
-  <package id="System.IO.Pipelines" version="4.7.1" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="4.7.4" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />


### PR DESCRIPTION
**Auth Denied fix** 
The existing implementation of the SafeguardDotNet PersistentEventListener handled expiration of the signalR listener's underlying connection but did not handle expiration of the access token in the ARSGJIT connection object. This is why we continue to receive signalr events when our token expires, but API queries from ARSGJIT using our connection fail. 

This change adds a check for an expired token every time the API is invoked and, if detected, uses the SafeguardDotNet RefreshAccessToken() method to obtain a new token. 

**LogLevel functionality**
Additionally a new -loglevel command line parameter is added to allow users to set log verbosity

**SafeguardDotNet update**
Finally SafeguardDotNet is updated to v6.9.0.